### PR TITLE
Fixed ModuleNotFoundError: No module named 'flask'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ WORKDIR /app
 
 COPY --from=backend-builder /app /app
 
+RUN pip install --no-cache-dir -r requirements.txt
+
 EXPOSE 5000
 
 CMD ["python", "app.py"]
-

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,2 @@
-Flask==2.0.1
+Flask
 


### PR DESCRIPTION
Even though we copied the files from the backend-builder stage, including the requirements.txt file, the Python dependencies are not automatically installed in the final image.

In the requirements.txt file, not mentioning any version, automatically installs the latest version. Hence it doesn't give the **ImportError: cannot import name 'url_quote' from 'werkzeug.urls'** error.